### PR TITLE
example tool url reader

### DIFF
--- a/tool/urlreader/reader.go
+++ b/tool/urlreader/reader.go
@@ -1,0 +1,235 @@
+package urlreader
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/mashiike/bedrocktool"
+)
+
+type ToolInput struct {
+	URL string `json:"url" jsonschema:"format=uri,required=true,description=read content from this URL."`
+}
+
+type Fetcher interface {
+	Fetch(ctx context.Context, u *url.URL) (<-chan string, error)
+}
+
+type FetcherFunc func(ctx context.Context, u *url.URL) (<-chan string, error)
+
+func (f FetcherFunc) Fetch(ctx context.Context, u *url.URL) (<-chan string, error) {
+	return f(ctx, u)
+}
+
+// New creates a new instance of the URL Reader Tool.
+func New(options bedrockruntime.Options, optFns ...func(*bedrockruntime.Options)) *Worker {
+	client := bedrockruntime.New(options, optFns...)
+	return NewWithClient(client)
+}
+
+// NewFromConfig creates a new instance of the URL Reader Tool.
+func NewFromConfig(cfg aws.Config, optFns ...func(*bedrockruntime.Options)) *Worker {
+	return NewWithClient(bedrockruntime.NewFromConfig(cfg, optFns...))
+}
+
+// NewWithClient creates a new instance of the URL Reader Tool.
+func NewWithClient(client bedrocktool.BedrockConverseAPIClient) *Worker {
+	w := &Worker{
+		logger: slog.Default().With("tool", "urlReader"),
+		client: client,
+	}
+	w.worker = bedrocktool.NewWorker(w.execute)
+	w.SetFetcher(nil)
+	return w
+}
+
+const (
+	ToolName        = "url_reader"
+	ToolDescription = "Read a URL, can not read the file content, only web content."
+)
+
+func Register(r bedrocktool.Registory, options bedrockruntime.Options, optFns ...func(*bedrockruntime.Options)) {
+	New(options, optFns...).RegisterTo(r)
+}
+
+func RegisterFromConfig(r bedrocktool.Registory, cfg aws.Config, optFns ...func(*bedrockruntime.Options)) {
+	NewFromConfig(cfg, optFns...).RegisterTo(r)
+}
+
+func RegisterWithClient(r bedrocktool.Registory, client bedrocktool.BedrockConverseAPIClient) {
+	NewWithClient(client).RegisterTo(r)
+}
+
+type Worker struct {
+	worker  bedrocktool.Worker
+	logger  *slog.Logger
+	fetcher Fetcher
+	client  bedrocktool.BedrockConverseAPIClient
+}
+
+func (w *Worker) RegisterTo(r bedrocktool.Registory) {
+	r.Register(ToolName, ToolDescription, w)
+}
+
+func (w *Worker) InputSchema() document.Interface {
+	return w.worker.InputSchema()
+}
+
+func (w *Worker) Execute(ctx context.Context, toolUse types.ToolUseBlock) (types.ToolResultBlock, error) {
+	return w.worker.Execute(ctx, toolUse)
+}
+
+func (w *Worker) Fetcher() Fetcher {
+	return w.fetcher
+}
+
+func (w *Worker) SetFetcher(f Fetcher) {
+	if f == nil {
+		f = FetcherFunc(func(ctx context.Context, u *url.URL) (<-chan string, error) {
+			resp, err := http.Get(u.String())
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch url; %w", err)
+			}
+			if resp.StatusCode >= 300 {
+				return nil, fmt.Errorf("failed to fetch url; %s", resp.Status)
+			}
+			defer resp.Body.Close()
+			bs, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body; %w", err)
+			}
+			ret := make(chan string, 1)
+			ret <- string(bs)
+			close(ret)
+			return ret, nil
+		})
+	}
+	w.fetcher = f
+}
+
+func (w *Worker) execute(ctx context.Context, input ToolInput) (types.ToolResultBlock, error) {
+	w.logger.DebugContext(ctx, "call url reader tool", "url", input.URL)
+	u, err := url.Parse(input.URL)
+	if err != nil {
+		return types.ToolResultBlock{
+			Content: []types.ToolResultContentBlock{
+				&types.ToolResultContentBlockMemberText{
+					Value: fmt.Sprintf("failed to parse url; %s", err),
+				},
+			},
+			Status: types.ToolResultStatusError,
+		}, nil
+	}
+	contents, err := w.fetcher.Fetch(ctx, u)
+	if err != nil {
+		return types.ToolResultBlock{
+			Content: []types.ToolResultContentBlock{
+				&types.ToolResultContentBlockMemberText{
+					Value: fmt.Sprintf("failed to fetch url content; %s", err),
+				},
+			},
+			Status: types.ToolResultStatusError,
+		}, nil
+	}
+	var builder strings.Builder
+	for content := range contents {
+		select {
+		case <-ctx.Done():
+			return types.ToolResultBlock{
+				Status: types.ToolResultStatusError,
+			}, ctx.Err()
+		default:
+		}
+
+		if err := w.extructContent(ctx, input, content, &builder); err != nil {
+			return types.ToolResultBlock{
+				Content: []types.ToolResultContentBlock{
+					&types.ToolResultContentBlockMemberText{
+						Value: fmt.Sprintf("failed to read content; %s", err),
+					},
+				},
+				Status: types.ToolResultStatusError,
+			}, nil
+		}
+	}
+	return types.ToolResultBlock{
+		Content: []types.ToolResultContentBlock{
+			&types.ToolResultContentBlockMemberText{
+				Value: builder.String(),
+			},
+		},
+	}, nil
+}
+
+var ModelID = "anthropic.claude-3-haiku-20240307-v1:0"
+
+const (
+	systemPromptTemplate = `
+You are a sophisticated AI to retrieve web content.
+Your job is to retrieve the body content from the given HTML.
+ Please retrieve the body of the content while preserving the original meaning and context.
+Please follow the guidelines below when retrieving.
+<guidelines>
+1. remove HTML tags.
+2. remove any elements that appear to be sidebars, navigation bars, etc.
+3. maintain the original content of the text, without guesswork or completion.
+</guidelines>
+Here is a portion of the HTML content for a site called "%s". Put the body content inside <output></output> XML tags.
+`
+)
+
+func (w *Worker) extructContent(ctx context.Context, input ToolInput, content string, builder *strings.Builder) error {
+	output, err := w.client.Converse(ctx, &bedrockruntime.ConverseInput{
+		ModelId: aws.String(ModelID),
+		System: []types.SystemContentBlock{
+			&types.SystemContentBlockMemberText{
+				Value: fmt.Sprintf(systemPromptTemplate, input.URL),
+			},
+		},
+		Messages: []types.Message{
+			{
+				Role: types.ConversationRoleUser,
+				Content: []types.ContentBlock{
+					&types.ContentBlockMemberText{
+						Value: content,
+					},
+				},
+			},
+			{
+				Role: types.ConversationRoleAssistant,
+				Content: []types.ContentBlock{
+					&types.ContentBlockMemberText{
+						Value: "<output>",
+					},
+				},
+			},
+		},
+		InferenceConfig: &types.InferenceConfiguration{
+			MaxTokens:     aws.Int32(3000),
+			StopSequences: []string{"</output>"},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to converse; %w", err)
+	}
+	msg, ok := output.Output.(*types.ConverseOutputMemberMessage)
+	if !ok {
+		return fmt.Errorf("unexpected output type; %T", output.Output)
+	}
+	for _, content := range msg.Value.Content {
+		switch c := content.(type) {
+		case *types.ContentBlockMemberText:
+			builder.WriteString(c.Value)
+		}
+	}
+	return nil
+}

--- a/tool/urlreader/reader.go
+++ b/tool/urlreader/reader.go
@@ -95,7 +95,11 @@ func (w *Worker) Fetcher() Fetcher {
 func (w *Worker) SetFetcher(f Fetcher) {
 	if f == nil {
 		f = FetcherFunc(func(ctx context.Context, u *url.URL) (<-chan string, error) {
-			resp, err := http.Get(u.String())
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create request; %w", err)
+			}
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch url; %w", err)
 			}

--- a/tool/urlreader/reader_test.go
+++ b/tool/urlreader/reader_test.go
@@ -1,0 +1,44 @@
+package urlreader_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/mashiike/bedrocktool/tool/urlreader"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUrlSummarizerWithAWS(t *testing.T) {
+	if !strings.EqualFold(os.Getenv("TEST_WITH_AWS"), "true") {
+		t.Skip("set TEST_WITH_AWS to run this test")
+	}
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx)
+	require.NoError(t, err)
+	tool := urlreader.NewFromConfig(cfg)
+	result, err := tool.Execute(ctx, types.ToolUseBlock{
+		Input: document.NewLazyDocument(map[string]interface{}{
+			"url":      "https://aws.amazon.com/jp/what-is-aws/",
+			"context":  "What is this page?",
+			"language": "english",
+		}),
+		Name:      aws.String(urlreader.ToolName),
+		ToolUseId: aws.String("test"),
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	for _, content := range result.Content {
+		switch c := content.(type) {
+		case *types.ToolResultContentBlockMemberText:
+			t.Logf("summary: %s", c.Value)
+		default:
+			require.Fail(t, "unexpected content type %T", content)
+		}
+	}
+}

--- a/tool_set.go
+++ b/tool_set.go
@@ -9,6 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 )
 
+type Registory interface {
+	Register(name string, description string, worker Worker, opts ...RegisterOption)
+}
+
 type ToolSet struct {
 	mu          sync.RWMutex
 	subToolSets []*ToolSet


### PR DESCRIPTION
example tool implement.

```go
package main

import (
	"context"
	"encoding/json"
	"fmt"

	"github.com/aws/aws-sdk-go-v2/aws"
	"github.com/aws/aws-sdk-go-v2/config"
	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
	"github.com/mashiike/bedrocktool"
	"github.com/mashiike/bedrocktool/tool/urlreader"
)

func main() {
	ctx := context.Background()
	opts := make([]func(*config.LoadOptions) error, 0)
	awsCfg, err := config.LoadDefaultConfig(ctx, opts...)
	if err != nil {
		panic("configuration error, " + err.Error())
	}
	d := bedrocktool.NewFromConfig(awsCfg)
	urlreader.RegisterFromConfig(d, awsCfg)

	output, err := d.Converse(ctx, &bedrockruntime.ConverseInput{
		ModelId: aws.String("anthropic.claude-3-sonnet-20240229-v1:0"),
		Messages: []types.Message{
			{
				Role: types.ConversationRoleUser,
				Content: []types.ContentBlock{
					&types.ContentBlockMemberText{
						Value: "https://aws.amazon.com/jp/s3/pricing/ このページの内容から、料金を要約して教えて。",
					},
				},
			},
		},
	})
	if err != nil {
		panic("converse error, " + err.Error())
	}
	toolUseByID := make(map[string]types.ToolUseBlock)
	for _, msg := range output {
		for _, content := range msg.Content {
			switch c := content.(type) {
			case *types.ContentBlockMemberText:
				fmt.Printf("[%s]:\t%s\n", msg.Role, c.Value)
			case *types.ContentBlockMemberImage:
				fmt.Printf("[%s]:\t<image %s>\n", msg.Role, c.Value.Format)
			case *types.ContentBlockMemberToolUse:
				toolUseByID[*c.Value.ToolUseId] = c.Value
			case *types.ContentBlockMemberToolResult:
				toolUse, ok := toolUseByID[*c.Value.ToolUseId]
				if !ok {
					fmt.Printf("tool use not found: %s\n", *c.Value.ToolUseId)
					continue
				}
				bs, err := json.Marshal(c.Value.Content)
				if err != nil {
					fmt.Printf("failed to marshal tool result: %s\n", err)
					continue
				}
				fmt.Printf("[%s]:\t%s\n", *toolUse.Name, string(bs))
			default:
			}
		}
	}
}
```