### PR TITLE
Remote Tool Utilitiy

### DIFF
--- a/tool/remote/handler.go
+++ b/tool/remote/handler.go
@@ -1,0 +1,135 @@
+package remote
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/mashiike/bedrocktool"
+)
+
+type Handler struct {
+	cfg                   HandlerConfig
+	workerEndpoint        *url.URL
+	specificationEndpoint *url.URL
+	inputSchema           json.RawMessage
+	mux                   *http.ServeMux
+}
+
+type HandlerConfig struct {
+	Endpoint        *url.URL
+	WorkerPath      string
+	ToolName        string
+	ToolDescription string
+	Worker          bedrocktool.Worker
+	Logger          *slog.Logger
+}
+
+var _ http.Handler = (*Handler)(nil)
+
+func NewHandler(cfg HandlerConfig) (*Handler, error) {
+	h := &Handler{
+		cfg: cfg,
+		mux: http.NewServeMux(),
+	}
+	if bedrocktool.ValidateToolName(cfg.ToolName) != nil {
+		return nil, errors.New("invalid tool name")
+	}
+	if cfg.Endpoint == nil {
+		return nil, errors.New("endpoint is required")
+	}
+	h.workerEndpoint = cfg.Endpoint.JoinPath(cfg.WorkerPath)
+	h.specificationEndpoint = cfg.Endpoint.JoinPath(SpecificationPath)
+	if cfg.Worker == nil {
+		return nil, errors.New("worker is required")
+	}
+	var err error
+	h.inputSchema, err = cfg.Worker.InputSchema().MarshalSmithyDocument()
+	if err != nil {
+		return nil, err
+	}
+	if h.cfg.Logger == nil {
+		h.cfg.Logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	}
+	h.mux.HandleFunc("/"+strings.TrimPrefix(h.workerEndpoint.Path, "/"), h.serveHTTPWorker)
+	h.mux.HandleFunc("/"+strings.TrimPrefix(h.specificationEndpoint.Path, "/"), h.serveHTTPSpecification)
+	return h, nil
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.cfg.Logger.InfoContext(r.Context(), "request", "method", r.Method, "url", r.URL)
+	h.mux.ServeHTTP(w, r)
+}
+
+var (
+	HeaderToolUseID = "Bedrock-Tool-Use-Id"
+	HeaderToolName  = "Bedrock-Tool-Name"
+)
+
+func (h *Handler) serveHTTPWorker(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var v interface{}
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		h.cfg.Logger.WarnContext(ctx, "failed to decode request body", "error", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	toolUse := types.ToolUseBlock{
+		Input:     document.NewLazyDocument(v),
+		Name:      aws.String(h.cfg.ToolName),
+		ToolUseId: aws.String(r.Header.Get(HeaderToolUseID)),
+	}
+	result, err := h.cfg.Worker.Execute(r.Context(), toolUse)
+	var tr ToolResult
+	if err != nil {
+		tr = ToolResult{
+			Status: "error",
+			Content: []ToolResultContent{
+				{
+					Type: "text",
+					Text: err.Error(),
+				},
+			},
+		}
+	} else {
+		if err := tr.UnmarshalTypes(result); err != nil {
+			h.cfg.Logger.WarnContext(ctx, "failed to marshal tool result", "error", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(tr); err != nil {
+		h.cfg.Logger.WarnContext(ctx, "failed to encode response", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(buf.Bytes())
+}
+
+func (h *Handler) serveHTTPSpecification(w http.ResponseWriter, _ *http.Request) {
+	spec := Specification{
+		Name:           h.cfg.ToolName,
+		Description:    h.cfg.ToolDescription,
+		InputSchema:    h.inputSchema,
+		WorkerEndpoint: h.workerEndpoint.String(),
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(spec); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(buf.Bytes())
+}

--- a/tool/remote/handler_test.go
+++ b/tool/remote/handler_test.go
@@ -1,0 +1,84 @@
+package remote
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/mashiike/bedrocktool"
+	"github.com/stretchr/testify/require"
+)
+
+type weatherInput struct {
+	City string `json:"city" jsonschema:"description=都市名 (例: 横浜,東京),default=東京, required=true"`
+	When string `json:"when" jsonschema:"description=日時 RFC3339 (例: 2022-01-01T00:00:00Z), required=false"`
+}
+
+func TestHandler(t *testing.T) {
+	u, err := url.Parse("http://localhost:8080/")
+	require.NoError(t, err)
+
+	h, err := NewHandler(HandlerConfig{
+		Endpoint:        u,
+		WorkerPath:      "/worker/execute",
+		ToolName:        "weather",
+		ToolDescription: "return weather",
+		Worker: bedrocktool.NewWorker(func(ctx context.Context, input weatherInput) (types.ToolResultBlock, error) {
+			require.EqualValues(t, "東京", input.City)
+			require.EqualValues(t, "2022-01-01T00:00:00Z", input.When)
+			return types.ToolResultBlock{
+				Content: []types.ToolResultContentBlock{
+					&types.ToolResultContentBlockMemberText{
+						Value: "sunny",
+					},
+				},
+				Status: types.ToolResultStatusSuccess,
+			}, nil
+		}),
+	})
+	require.NoError(t, err)
+	specReq := httptest.NewRequest(http.MethodGet, "http://localhost:8080/.well-known/bedrock-tool-specification", nil)
+	specResp := httptest.NewRecorder()
+	h.ServeHTTP(specResp, specReq)
+	require.Equal(t, http.StatusOK, specResp.Code)
+	t.Log(specResp.Body.String())
+	expected := `{
+  "name": "weather",
+  "description": "return weather",
+  "input_schema": {
+    "$id": "https://github.com/mashiike/bedrocktool/tool/remote/weather-input",
+    "properties": {
+      "city": {
+        "default": "東京",
+        "type": "string",
+        "description": "都市名 (例: 横浜"
+      },
+      "when": {
+        "type": "string",
+        "description": "日時 RFC3339 (例: 2022-01-01T00:00:00Z)"
+      }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+      "city",
+      "when"
+    ]
+  },
+  "worker_endpoint": "http://localhost:8080/worker/execute"
+}`
+
+	require.JSONEq(t, expected, specResp.Body.String())
+	input := `{"city":"東京","when":"2022-01-01T00:00:00Z"}`
+	workerReq := httptest.NewRequest(http.MethodPost, "http://localhost:8080/worker/execute", strings.NewReader(input))
+	workerResp := httptest.NewRecorder()
+	h.ServeHTTP(workerResp, workerReq)
+	require.Equal(t, http.StatusOK, workerResp.Code)
+	t.Log(workerResp.Body.String())
+	expected = `{"content":[{"type":"text","text":"sunny"}],"status":"success"}`
+	require.JSONEq(t, expected, workerResp.Body.String())
+}

--- a/tool/remote/spec.go
+++ b/tool/remote/spec.go
@@ -1,0 +1,18 @@
+package remote
+
+import "encoding/json"
+
+type Specification struct {
+	// Name of the tool.
+	Name string `json:"name"`
+	// Description of the tool.
+	Description string `json:"description,omitempty"`
+	// InputSchema of the tool.
+	InputSchema json.RawMessage `json:"input_schema"`
+	// WorkerEndpoint of the tool.
+	WorkerEndpoint string `json:"worker_endpoint"`
+	// VerifyEndpoint of the tool. (optional) check for tool execution authorization.
+	VerifyEndpoint string `json:"verify_endpoint,omitempty"`
+}
+
+var SpecificationPath = "/.well-known/bedrock-tool-specification"

--- a/tool/remote/tool.go
+++ b/tool/remote/tool.go
@@ -1,0 +1,249 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/mashiike/bedrocktool"
+)
+
+type SpecificationCache struct {
+	mu             sync.RWMutex
+	cache          map[string]Specification
+	expireDuration time.Duration
+}
+
+func NewSpecificationCache(expireDuration time.Duration) *SpecificationCache {
+	return &SpecificationCache{
+		cache:          make(map[string]Specification),
+		expireDuration: expireDuration,
+	}
+}
+
+func (sc *SpecificationCache) Get(name string) (Specification, bool) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	spec, ok := sc.cache[name]
+	return spec, ok
+}
+
+func (sc *SpecificationCache) Set(name string, spec Specification) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.cache[name] = spec
+}
+
+var DefaultSpecificationCache = NewSpecificationCache(15 * time.Minute)
+
+type Tool struct {
+	endpoint    *url.URL
+	spec        Specification
+	newReqFunc  RequestConstructor
+	inputSchema document.Interface
+	client      *http.Client
+	newErr      func(error) (types.ToolResultBlock, error)
+	signer      func(*http.Request) (*http.Request, error)
+}
+
+type RequestConstructor func(ctx context.Context, method string, url string, toolUse types.ToolUseBlock) (*http.Request, error)
+
+var DefaultRequestConstructor = func(ctx context.Context, method string, url string, toolUse types.ToolUseBlock) (*http.Request, error) {
+	bs, err := toolUse.Input.MarshalSmithyDocument()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(bs))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if toolUse.ToolUseId != nil {
+		req.Header.Set(HeaderToolUseID, *toolUse.ToolUseId)
+	}
+	if toolUse.Name != nil {
+		req.Header.Set(HeaderToolName, *toolUse.Name)
+	}
+	return req, nil
+}
+
+type ToolConfig struct {
+	Endpoint           string
+	SpecificationPath  string
+	SpecificationCache *SpecificationCache
+	RequestConstructor RequestConstructor
+	HTTPClient         *http.Client
+	ErrorConstractor   func(error) (types.ToolResultBlock, error)
+	RequestSigner      func(*http.Request) (*http.Request, error)
+}
+
+type remoteWorker struct {
+	tool *Tool
+}
+
+func NewTool(ctx context.Context, cfg ToolConfig) (*Tool, error) {
+	if cfg.Endpoint == "" {
+		return nil, errors.New("endpoint is required")
+	}
+	if cfg.SpecificationCache == nil {
+		cfg.SpecificationCache = DefaultSpecificationCache
+	}
+	if cfg.RequestConstructor == nil {
+		cfg.RequestConstructor = DefaultRequestConstructor
+	}
+	if cfg.SpecificationPath == "" {
+		cfg.SpecificationPath = SpecificationPath
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+	if cfg.ErrorConstractor == nil {
+		cfg.ErrorConstractor = func(err error) (types.ToolResultBlock, error) {
+			return types.ToolResultBlock{}, err
+		}
+	}
+	if cfg.RequestSigner == nil {
+		cfg.RequestSigner = func(req *http.Request) (*http.Request, error) {
+			return req, nil
+		}
+	}
+	u, err := url.Parse(cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	u = u.JoinPath(cfg.SpecificationPath)
+	t := &Tool{
+		endpoint:   u,
+		newReqFunc: cfg.RequestConstructor,
+		client:     cfg.HTTPClient,
+		newErr:     cfg.ErrorConstractor,
+		signer:     cfg.RequestSigner,
+	}
+	spec, ok := cfg.SpecificationCache.Get(u.String())
+	if !ok {
+		spec, err = t.fetchSpecification(ctx)
+		if err != nil {
+			return nil, err
+		}
+		cfg.SpecificationCache.Set(u.String(), spec)
+	}
+	t.spec = spec
+	if bedrocktool.ValidateToolName(spec.Name) != nil {
+		return nil, errors.New("invalid tool name")
+	}
+	var v interface{}
+	if err := json.Unmarshal(spec.InputSchema, &v); err != nil {
+		return nil, err
+	}
+	t.inputSchema = document.NewLazyDocument(v)
+	return t, nil
+}
+
+func (t *Tool) fetchSpecification(ctx context.Context) (Specification, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, t.endpoint.String(), nil)
+	if err != nil {
+		return Specification{}, err
+	}
+	req, err = t.signer(req)
+	if err != nil {
+		return Specification{}, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return Specification{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Specification{}, errors.New("failed to fetch specification")
+	}
+	var spec Specification
+	if err := json.NewDecoder(resp.Body).Decode(&spec); err != nil {
+		return Specification{}, err
+	}
+	return spec, nil
+}
+
+var _ bedrocktool.Tool = (*Tool)(nil)
+var _ bedrocktool.Worker = (*remoteWorker)(nil)
+
+func (t *Tool) Name() string {
+	return t.spec.Name
+}
+
+func (t *Tool) Description() string {
+	return t.spec.Description
+}
+
+func (t *Tool) Specification() Specification {
+	return t.spec
+}
+
+func (t *Tool) Worker() bedrocktool.Worker {
+	return &remoteWorker{
+		tool: t,
+	}
+}
+
+func (w *remoteWorker) InputSchema() document.Interface {
+	return w.tool.inputSchema
+}
+
+func (w *remoteWorker) Execute(ctx context.Context, toolUse types.ToolUseBlock) (types.ToolResultBlock, error) {
+	req, err := w.tool.newReqFunc(ctx, http.MethodPost, w.tool.spec.WorkerEndpoint, toolUse)
+	if err != nil {
+		return w.tool.newErr(fmt.Errorf("failed to create request; %w", err))
+	}
+	req, err = w.tool.signer(req)
+	if err != nil {
+		return w.tool.newErr(fmt.Errorf("failed to sign request; %w", err))
+	}
+	resp, err := w.tool.client.Do(req)
+	if err != nil {
+		return w.tool.newErr(fmt.Errorf("failed to fetch url; %w", err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return w.tool.newErr(errors.New("status code is not 200"))
+	}
+	var tr ToolResult
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return w.tool.newErr(fmt.Errorf("failed to decode response; %w", err))
+	}
+	trb, err := tr.MarshalTypes()
+	if err != nil {
+		return w.tool.newErr(fmt.Errorf("failed to marshal response; %w", err))
+	}
+	return trb, nil
+}
+
+func (t *Tool) Verify(ctx context.Context, body io.Reader) error {
+	if t.spec.VerifyEndpoint == "" {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.spec.VerifyEndpoint, body)
+	if err != nil {
+		return err
+	}
+	req, err = t.signer(req)
+	if err != nil {
+		return err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("status code is not 200")
+	}
+	return nil
+}

--- a/tool/remote/tool_result.go
+++ b/tool/remote/tool_result.go
@@ -1,0 +1,116 @@
+package remote
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+type ToolResult struct {
+	Content []ToolResultContent `json:"content,omitempty"`
+	Status  string              `json:"status,omitempty"`
+}
+
+func (tr ToolResult) MarshalTypes() (types.ToolResultBlock, error) {
+	content := make([]types.ToolResultContentBlock, 0, len(tr.Content))
+	for _, c := range tr.Content {
+		tc, err := c.MarshalTypes()
+		if err != nil {
+			return types.ToolResultBlock{}, err
+		}
+		content = append(content, tc)
+	}
+	return types.ToolResultBlock{
+		Content: content,
+		Status:  types.ToolResultStatus(tr.Status),
+	}, nil
+}
+
+func (tr *ToolResult) UnmarshalTypes(t types.ToolResultBlock) error {
+	tr.Status = string(t.Status)
+	tr.Content = make([]ToolResultContent, 0, len(t.Content))
+	for _, c := range t.Content {
+		var tc ToolResultContent
+		if err := tc.UnmarshalTypes(c); err != nil {
+			return err
+		}
+		tr.Content = append(tr.Content, tc)
+	}
+	return nil
+}
+
+type ToolResultContent struct {
+	Type   string `json:"type"`
+	Text   string `json:"text,omitempty"`
+	Format string `json:"format,omitempty"`
+	JSON   string `json:"json,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Source []byte `json:"source,omitempty"`
+}
+
+func (trc ToolResultContent) MarshalTypes() (types.ToolResultContentBlock, error) {
+	switch trc.Type {
+	case "text":
+		return &types.ToolResultContentBlockMemberText{
+			Value: trc.Text,
+		}, nil
+	case "json":
+		var v interface{}
+		if err := json.Unmarshal([]byte(trc.JSON), &v); err != nil {
+			return nil, err
+		}
+		return &types.ToolResultContentBlockMemberJson{
+			Value: document.NewLazyDocument(v),
+		}, nil
+	case "document":
+		return &types.ToolResultContentBlockMemberDocument{
+			Value: types.DocumentBlock{
+				Format: types.DocumentFormat(trc.Format),
+				Name:   &trc.Name,
+				Source: &types.DocumentSourceMemberBytes{
+					Value: trc.Source,
+				},
+			},
+		}, nil
+	case "image":
+		return &types.ToolResultContentBlockMemberImage{
+			Value: types.ImageBlock{
+				Format: types.ImageFormat(trc.Format),
+				Source: &types.ImageSourceMemberBytes{
+					Value: trc.Source,
+				},
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported content type: %s", trc.Type)
+	}
+}
+
+func (trc *ToolResultContent) UnmarshalTypes(t types.ToolResultContentBlock) error {
+	switch c := t.(type) {
+	case *types.ToolResultContentBlockMemberText:
+		trc.Type = "text"
+		trc.Text = c.Value
+	case *types.ToolResultContentBlockMemberJson:
+		trc.Type = "json"
+		bs, err := c.Value.MarshalSmithyDocument()
+		if err != nil {
+			return err
+		}
+		trc.JSON = string(bs)
+	case *types.ToolResultContentBlockMemberDocument:
+		trc.Type = "document"
+		trc.Format = string(c.Value.Format)
+		trc.Name = *c.Value.Name
+		trc.Source = c.Value.Source.(*types.DocumentSourceMemberBytes).Value
+	case *types.ToolResultContentBlockMemberImage:
+		trc.Type = "image"
+		trc.Format = string(c.Value.Format)
+		trc.Source = c.Value.Source.(*types.ImageSourceMemberBytes).Value
+	default:
+		return fmt.Errorf("unsupported content type: %T", t)
+	}
+	return nil
+}

--- a/tool/remote/tool_result_test.go
+++ b/tool/remote/tool_result_test.go
@@ -1,0 +1,83 @@
+package remote
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolResult__Marshal(t *testing.T) {
+	toolResult := types.ToolResultBlock{
+		Content: []types.ToolResultContentBlock{
+			&types.ToolResultContentBlockMemberText{
+				Value: "Hello, World!",
+			},
+			&types.ToolResultContentBlockMemberJson{
+				Value: document.NewLazyDocument(map[string]interface{}{
+					"key": "value",
+				}),
+			},
+			&types.ToolResultContentBlockMemberDocument{
+				Value: types.DocumentBlock{
+					Format: types.DocumentFormatCsv,
+					Name:   aws.String("example"),
+					Source: &types.DocumentSourceMemberBytes{
+						Value: []byte("a,b,c\n1,2,3"),
+					},
+				},
+			},
+			&types.ToolResultContentBlockMemberImage{
+				Value: types.ImageBlock{
+					Format: types.ImageFormatPng,
+					Source: &types.ImageSourceMemberBytes{
+						Value: []byte("image data"),
+					},
+				},
+			},
+		},
+		Status: types.ToolResultStatusSuccess,
+	}
+	var tr ToolResult
+	err := tr.UnmarshalTypes(toolResult)
+	require.NoError(t, err)
+	bs, err := json.MarshalIndent(tr, "", "  ")
+	require.NoError(t, err)
+	expected := `{
+	"content": [
+		{
+			"type": "text",
+			"text": "Hello, World!"
+		},
+		{
+			"type": "json",
+			"json": "{\"key\":\"value\"}"
+		},
+		{
+			"type": "document",
+			"format": "csv",
+			"name": "example",
+			"source": "YSxiLGMKMSwyLDM="
+		},
+		{
+			"type": "image",
+			"format": "png",
+			"source": "aW1hZ2UgZGF0YQ=="
+		}
+	],
+	"status": "success"
+}
+`
+	t.Log(string(bs))
+	require.JSONEq(t, expected, string(bs))
+	var tr2 ToolResult
+	err = json.Unmarshal(bs, &tr2)
+	require.NoError(t, err)
+	require.EqualValues(t, tr, tr2)
+	acutal, err := tr2.MarshalTypes()
+	require.NoError(t, err)
+	require.EqualValues(t, toolResult, acutal)
+}

--- a/tool/remote/tool_test.go
+++ b/tool/remote/tool_test.go
@@ -1,0 +1,64 @@
+package remote
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/mashiike/bedrocktool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteTool(t *testing.T) {
+	var h http.Handler
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("request: %s %s", r.Method, r.URL)
+		h.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	h, err = NewHandler(HandlerConfig{
+		Endpoint:        u,
+		WorkerPath:      "/worker/execute",
+		ToolName:        "weather",
+		ToolDescription: "return weather",
+		Worker: bedrocktool.NewWorker(func(ctx context.Context, input weatherInput) (types.ToolResultBlock, error) {
+			require.EqualValues(t, "東京", input.City)
+			require.EqualValues(t, "2022-01-01T00:00:00Z", input.When)
+			require.EqualValues(t, "weather", bedrocktool.ToolName(ctx))
+			require.EqualValues(t, "test", bedrocktool.ToolUseID(ctx))
+			return types.ToolResultBlock{
+				Content: []types.ToolResultContentBlock{
+					&types.ToolResultContentBlockMemberText{
+						Value: "sunny",
+					},
+				},
+				Status: types.ToolResultStatusSuccess,
+			}, nil
+		}),
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tool, err := NewTool(ctx, ToolConfig{
+		Endpoint: server.URL,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "weather", tool.Name())
+	require.Equal(t, "return weather", tool.Description())
+	result, err := tool.Worker().Execute(ctx, types.ToolUseBlock{
+		Name:      aws.String("weather"),
+		Input:     document.NewLazyDocument(weatherInput{City: "東京", When: "2022-01-01T00:00:00Z"}),
+		ToolUseId: aws.String("test"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.ToolResultStatusSuccess, result.Status)
+	require.Len(t, result.Content, 1)
+	require.Equal(t, "sunny", result.Content[0].(*types.ToolResultContentBlockMemberText).Value)
+}


### PR DESCRIPTION
tool server:
```go 
package main

import (
    "context"
    "log"
    "net/http"
    "net/url"

    "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
    "github.com/mashiike/bedrocktool"
)

type weatherInput struct {
    City string `json:"city"`
    When string `json:"when"`
}

func main() {
    u, err := url.Parse("http://localhost:8080")
    if err != nil {
        log.Fatalf("Failed to parse URL: %v", err)
    }

    h, err := NewHandler(HandlerConfig{
        Endpoint:        u,
        WorkerPath:      "/worker/execute",
        ToolName:        "weather",
        ToolDescription: "return weather",
        Worker: bedrocktool.NewWorker(func(ctx context.Context, input weatherInput) (types.ToolResultBlock, error) {
            if input.City != "東京" || input.When != "2022-01-01T00:00:00Z" {
                return types.ToolResultBlock{}, errors.New("invalid input")
            }
            return types.ToolResultBlock{
                Content: []types.ToolResultContentBlock{
                    &types.ToolResultContentBlockMemberText{
                        Value: "sunny",
                    },
                },
                Status: types.ToolResultStatusSuccess,
            }, nil
        }),
    })
    if err != nil {
        log.Fatalf("Failed to create handler: %v", err)
    }

    http.Handle("/", h)
    log.Println("Starting server on :8080")
    if err := http.ListenAndServe(":8080", nil); err != nil {
        log.Fatalf("Failed to start server: %v", err)
    }
}
```
client 
```go 
d := bedrocktool.NewFromConfig(awsCfg)
tool, err := NewTool(ctx, ToolConfig{
　　Endpoint: "http://localhost:8080/"
})
if err != nil {
  // ...
}
d.RegisterTool(tool)
output, err := d.Converse(ctx, &bedrockruntime.ConverseInput{
//... 
// this is the same input as bedrockruntime.ConverseInput
// but, ToolConfig is generated by bedrocktool.Dispacher, so you don't need to specify it.
})
```